### PR TITLE
fix: get real current position on touch event - fix #43

### DIFF
--- a/src/components/prefabs/drag-container/drag-container.component.tsx
+++ b/src/components/prefabs/drag-container/drag-container.component.tsx
@@ -83,6 +83,10 @@ const DragContainerComponentWrapper: FC<DragContainerComponentProps> = ({
     containerRef.current.component.zIndex = maxZIndex;
 
     $firstPosition.current = { ...containerRef.current.position };
+
+    // TODO: Check the race condition here. The problem is that this getCursorPosition() is called BEFORE the use-cursor
+    // onPointerDown, so the position used here is the LAST set position (which is the last onPointerMove position), not the
+    // current one
     $firstCursorPosition.current = getCursorPosition();
     setCursor(Cursor.GRABBING);
   }, [getCursorPosition, getScale, maxZIndex]);

--- a/src/hooks/use-cursor.tsx
+++ b/src/hooks/use-cursor.tsx
@@ -31,8 +31,8 @@ export const CursorProvider: FC<CursorProps> = ({ children }) => {
 
   const position = useRef<Point>({ x: 0, y: 0 });
 
-  const onPointerMove = useCallback(
-    (event: MouseEvent | TouchEvent) => {
+  const getPositionFromEvent = useCallback(
+    (event: MouseEvent | TouchEvent): Point => {
       let targetX = 0;
       let targetY = 0;
 
@@ -45,22 +45,31 @@ export const CursorProvider: FC<CursorProps> = ({ children }) => {
         targetY = touch.clientY;
       }
 
-      const $position = {
+      return {
         x: normalizeValue(targetX),
         y: normalizeValue(targetY),
       };
+    },
+    [normalizeValue],
+  );
 
-      if (position.current.x === targetX && position.current.y === targetY)
-        return;
-
+  const onPointerMove = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      const $position = getPositionFromEvent(event);
       position.current = $position;
       emit(Event.CURSOR_MOVE, $position);
     },
     [normalizeValue, on, emit],
   );
-  const onPointerDown = useCallback(() => {
-    emit(Event.CURSOR_DOWN, position.current);
-  }, [emit]);
+
+  const onPointerDown = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      const $position = getPositionFromEvent(event);
+      position.current = $position;
+      emit(Event.CURSOR_DOWN, $position);
+    },
+    [normalizeValue, emit],
+  );
 
   const setCursor = useCallback(
     (cursor: Cursor) => {


### PR DESCRIPTION
The logic works fine: now the position returned on the pointerDown is really the current position. Previously, for touch events, it didn't work since the onMove works AFTER the onDown, so with touch you would have:

1. I touch down the screen on position 0,0
2. I move until position 10,10. Now position is set to 10,10
3. I touch up and move my finger physically to 50,50 (so it's not registered on the onMove)
4. I touch down the screen on position 50,50
5. If I don't move, the current position will be 10,10, because it's the LAST time the onMove was triggered


NOTE:

There's a race condition, see the TODO